### PR TITLE
use ESNext target and ESModule format

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ Build the executable binary.
 This is the easiest way to create an executable binary (although the release process uses the goreleaser tool to create release versions).
 
 ```
-go build -ldflags="-w -s" -o build/k6pack .
+go build -ldflags="-w -s" -o build/k6pack ./cmd/k6pack
 ```
 
 #### snapshot

--- a/internal/plugins/k6/plugin.go
+++ b/internal/plugins/k6/plugin.go
@@ -59,11 +59,11 @@ func setOptions(opts *api.BuildOptions) {
 	}
 
 	if opts.Target == api.DefaultTarget {
-		opts.Target = api.ES2017
+		opts.Target = api.ESNext
 	}
 
 	if opts.Format == api.FormatDefault {
-		opts.Format = api.FormatCommonJS
+		opts.Format = api.FormatESModule
 	}
 
 	if opts.LegalComments == api.LegalCommentsDefault {

--- a/pack_test.go
+++ b/pack_test.go
@@ -1,7 +1,6 @@
 package k6pack_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/grafana/k6pack"
@@ -28,19 +27,13 @@ const user : User = newUser("John")
 console.log(user)
 `, &k6pack.Options{TypeScript: true})
 
-	fmt.Println(string(src))
-
 	require.NoError(t, err)
 
-	exp := /*js*/ `var __defProp = Object.defineProperty;
-var __defNormalProp = (obj, key, value) => key in obj ? __defProp(obj, key, { enumerable: true, configurable: true, writable: true, value }) : obj[key] = value;
-var __publicField = (obj, key, value) => __defNormalProp(obj, typeof key !== "symbol" ? key + "" : key, value);
-
-// examples/user.ts
+	exp := /*js*/ `// examples/user.ts
 var UserAccount = class {
+  name;
+  id;
   constructor(name) {
-    __publicField(this, "name");
-    __publicField(this, "id");
     this.name = name;
     this.id = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
   }

--- a/releases/v0.2.3.md
+++ b/releases/v0.2.3.md
@@ -1,0 +1,6 @@
+k6pack `v0.2.3` is here 🎉!
+
+This release contains: change esbuild target to ESNext and format to ESModule.
+
+
+Some JavaScript constructs already supported by k6 will only work correctly with esbuild when using the ESNext esbuild target and ESModule format.


### PR DESCRIPTION
Some JavaScript constructs already supported by k6 will only work correctly with esbuild when using the ESNext esbuild target and ESModule format.